### PR TITLE
Improve description of bit32.extract.

### DIFF
--- a/docs/_pages/library.md
+++ b/docs/_pages/library.md
@@ -683,7 +683,7 @@ Perform a bitwise `and` of all input numbers, and return `true` iff the result i
 function bit32.extract(n: number, f: number, w: number?): number
 ```
 
-Extracts bits at positions `[f..w]` and returns the resulting integer. `w` defaults to `f+1`, so a two-argument version of `extract` returns the bit value at position `f`.
+Extracts bits of `n` at position `f` with a width of `w`, and returns the resulting integer. `w` defaults to `1`, so a two-argument version of `extract` returns the bit value at position `f`. Bits are indexed starting at 0. Errors if `f` and `f+w-1` are not between 0 and 31.
 
 ```
 function bit32.lrotate(n: number, i: number): number


### PR DESCRIPTION
Fix description incorrectly saying that parameter w specifies an upper range. w is actually a width. Proof:

    print(bit32.extract(2^32-1, 3, 4)) -- prints 15, not 1.

Also indicate that the position is 0-based, and that the function will error if the selected range exceeds the allowed bounds.